### PR TITLE
[bugfix] use try/except to import lazyattr

### DIFF
--- a/napari_czifile2/io.py
+++ b/napari_czifile2/io.py
@@ -4,7 +4,10 @@ from xml.etree import ElementTree
 
 import numpy as np
 from czifile import CziFile, DimensionEntryDV1, DirectoryEntryDV
-from tifffile import lazyattr
+try:
+    from tifffile import lazyattr
+except ImportError:
+    from czifile.czifile import lazyattr
 
 
 class CZISceneFile(CziFile):

--- a/napari_czifile2/io.py
+++ b/napari_czifile2/io.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree
 
 import numpy as np
 from czifile import CziFile, DimensionEntryDV1, DirectoryEntryDV
+
 try:
     from tifffile import lazyattr
 except ImportError:


### PR DESCRIPTION
In tifffile 2025.2.18 `lazyattr` was removed.
In czifile 2019.7.2.1 `lazyattr` was added.

This PR uses try/except to get lazyattr imported, first checking tifffile (to keep backwards compatibility) and then czifile.

I tested locally. Before this PR, I cannot load CZI without also doing `tifffile<2025.2.18`. With this PR, the same file opens again.