### PR TITLE
fix import error due to changes to tifffile

### DIFF
--- a/napari_czifile2/io.py
+++ b/napari_czifile2/io.py
@@ -4,7 +4,13 @@ from xml.etree import ElementTree
 
 import numpy as np
 from czifile import CziFile, DimensionEntryDV1, DirectoryEntryDV
-from tifffile import lazyattr
+try:
+    from tifffile import lazyattr
+except ImportError:
+    from czifile.czifile import lazyattr
+    # lazyattr was moved from tifffile to czifile
+    # in tiffile==2025.3.13 and czifile==2019.7.2.1
+
 
 
 class CZISceneFile(CziFile):

--- a/napari_czifile2/io.py
+++ b/napari_czifile2/io.py
@@ -4,13 +4,14 @@ from xml.etree import ElementTree
 
 import numpy as np
 from czifile import CziFile, DimensionEntryDV1, DirectoryEntryDV
+
 try:
     from tifffile import lazyattr
 except ImportError:
     from czifile.czifile import lazyattr
+
     # lazyattr was moved from tifffile to czifile
     # in tiffile==2025.3.13 and czifile==2019.7.2.1
-
 
 
 class CZISceneFile(CziFile):


### PR DESCRIPTION
lazyattr was moved from tifffile to czifile in tiffile==2025.3.13 and czifile==2019.7.2.1 this change simply imports from whichever works